### PR TITLE
Add Joke Controller and Tests

### DIFF
--- a/src/main/java/edu/ucsb/cs156/spring/backenddemo/controllers/JokeController.java
+++ b/src/main/java/edu/ucsb/cs156/spring/backenddemo/controllers/JokeController.java
@@ -2,7 +2,43 @@ package edu.ucsb.cs156.spring.backenddemo.controllers;
 
 import org.springframework.web.bind.annotation.RestController;
 
+import edu.ucsb.cs156.spring.backenddemo.services.JokeQueryService;
+import lombok.extern.slf4j.Slf4j;
+
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.ResponseEntity;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.tags.Tag;
+
+
+@Tag(name="Jokes from https://v2.jokeapi.dev/")
+@Slf4j
 @RestController
+@RequestMapping("/api/jokes")
 public class JokeController {
-    
+    ObjectMapper mapper = new ObjectMapper();
+
+    @Autowired
+    JokeQueryService jokeQueryService;
+    @Operation(summary = "Get jokes for a given category and amount")
+    /* description = "Valid categories are: Any, Misc, Programming, Dark, Pun, Spooky, Christmas" */
+    @GetMapping("/get")
+
+    public ResponseEntity<String> getJokes(
+        /* possible categories are:"Any, Misc, Programming, Dark, Pun, Spooky, Christmas */
+        @Parameter(name="amount", description="amount of jokes to get, e.g. '1' or '2'", example="'1' or '2'") @RequestParam String numJokes,
+        @Parameter(name="category", description="category of joke", example="'Programming' or 'Spooky'") @RequestParam String category
+    ) throws JsonProcessingException {
+        log.info("getJokes: category={} numJokes={}", category, numJokes);
+        String result = jokeQueryService.getJSON(category, numJokes);
+        return ResponseEntity.ok().body(result);
+    }
 }

--- a/src/main/java/edu/ucsb/cs156/spring/backenddemo/controllers/JokeController.java
+++ b/src/main/java/edu/ucsb/cs156/spring/backenddemo/controllers/JokeController.java
@@ -18,8 +18,7 @@ import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.tags.Tag;
 
-
-@Tag(name="Jokes from https://v2.jokeapi.dev/")
+@Tag(name = "Jokes from https://v2.jokeapi.dev/")
 @Slf4j
 @RestController
 @RequestMapping("/api/jokes")
@@ -28,17 +27,23 @@ public class JokeController {
 
     @Autowired
     JokeQueryService jokeQueryService;
+
     @Operation(summary = "Get jokes for a given category and amount")
-    /* description = "Valid categories are: Any, Misc, Programming, Dark, Pun, Spooky, Christmas" */
+    /*
+     * description =
+     * "Valid categories are: Any, Misc, Programming, Dark, Pun, Spooky, Christmas"
+     */
     @GetMapping("/get")
 
     public ResponseEntity<String> getJokes(
-        /* possible categories are:"Any, Misc, Programming, Dark, Pun, Spooky, Christmas */
-        @Parameter(name="amount", description="amount of jokes to get, e.g. '1' or '2'", example="'1' or '2'") @RequestParam String numJokes,
-        @Parameter(name="category", description="category of joke", example="'Programming' or 'Spooky'") @RequestParam String category
-    ) throws JsonProcessingException {
-        log.info("getJokes: category={} numJokes={}", category, numJokes);
-        String result = jokeQueryService.getJSON(category, numJokes);
+            /*
+             * possible categories are:"Any, Misc, Programming, Dark, Pun, Spooky, Christmas
+             */
+            @Parameter(name = "amount", description = "amount of jokes to get", example = "2") @RequestParam String amount,
+            @Parameter(name = "category", description = "category of joke", example = "Any") @RequestParam String category)
+            throws JsonProcessingException {
+        log.info("getJokes: category={} amount={}", category, amount);
+        String result = jokeQueryService.getJSON(category, amount);
         return ResponseEntity.ok().body(result);
     }
 }

--- a/src/main/java/edu/ucsb/cs156/spring/backenddemo/services/JokeQueryService.java
+++ b/src/main/java/edu/ucsb/cs156/spring/backenddemo/services/JokeQueryService.java
@@ -15,7 +15,7 @@ public class JokeQueryService {
         restTemplate = restTemplateBuilder.build();
     }
 
-    public static final String ENDPOINT = "";
+    public static final String ENDPOINT = "https://v2.jokeapi.dev/joke/{category}?amount={numJokes}";
 
     public String getJSON(String category, int numJokes) throws HttpClientErrorException {
         return "";

--- a/src/main/java/edu/ucsb/cs156/spring/backenddemo/services/JokeQueryService.java
+++ b/src/main/java/edu/ucsb/cs156/spring/backenddemo/services/JokeQueryService.java
@@ -1,11 +1,26 @@
 package edu.ucsb.cs156.spring.backenddemo.services;
 
-import org.springframework.boot.web.client.RestTemplateBuilder;
-import org.springframework.stereotype.Service;
-import org.springframework.web.client.HttpClientErrorException;
+import java.net.http.HttpClient;
+import java.util.List;
+import java.util.Map;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+
 import org.springframework.web.client.RestTemplate;
 
+import lombok.extern.slf4j.Slf4j;
 
+import org.springframework.boot.web.client.RestTemplateBuilder;
+import org.springframework.http.HttpEntity;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpMethod;
+import org.springframework.http.MediaType;
+import org.springframework.http.ResponseEntity;
+import org.springframework.stereotype.Service;
+import org.springframework.web.client.HttpClientErrorException;
+
+
+@Slf4j
 @Service
 public class JokeQueryService {
 
@@ -18,6 +33,20 @@ public class JokeQueryService {
     public static final String ENDPOINT = "https://v2.jokeapi.dev/joke/{category}?amount={numJokes}";
 
     public String getJSON(String category, int numJokes) throws HttpClientErrorException {
-        return "";
+        log.info("category={}, numJokes={}", category, numJokes);
+
+        HttpHeaders headers = new HttpHeaders();
+        headers.setAccept(List.of(MediaType.APPLICATION_JSON));
+        headers.setContentType(MediaType.APPLICATION_JSON);
+        HttpEntity<String> entity = new HttpEntity<>(headers);
+
+        Map<String, String> uriVariables = Map.of(
+            "category", category,
+            "numJokes", Integer.toString(numJokes)
+        );
+
+        ResponseEntity<String> response = restTemplate.exchange(ENDPOINT, HttpMethod.GET, entity, String.class,
+                uriVariables);
+        return response.getBody();
     }
 }

--- a/src/main/java/edu/ucsb/cs156/spring/backenddemo/services/JokeQueryService.java
+++ b/src/main/java/edu/ucsb/cs156/spring/backenddemo/services/JokeQueryService.java
@@ -19,7 +19,6 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.stereotype.Service;
 import org.springframework.web.client.HttpClientErrorException;
 
-
 @Slf4j
 @Service
 public class JokeQueryService {
@@ -30,10 +29,10 @@ public class JokeQueryService {
         restTemplate = restTemplateBuilder.build();
     }
 
-    public static final String ENDPOINT = "https://v2.jokeapi.dev/joke/get?category={category}?amount={numJokes}";
+    public static final String ENDPOINT = "https://v2.jokeapi.dev/joke/{category}?amount={amount}";
 
-    public String getJSON(String category, String numJokes) throws HttpClientErrorException {
-        log.info("category={}, numJokes={}", category, numJokes);
+    public String getJSON(String category, String amount) throws HttpClientErrorException {
+        log.info("category={}, amount={}", category, amount);
 
         HttpHeaders headers = new HttpHeaders();
         headers.setAccept(List.of(MediaType.APPLICATION_JSON));
@@ -41,9 +40,8 @@ public class JokeQueryService {
         HttpEntity<String> entity = new HttpEntity<>(headers);
 
         Map<String, String> uriVariables = Map.of(
-            "category", category,
-            "numJokes", numJokes
-        );
+                "category", category,
+                "amount", amount);
 
         ResponseEntity<String> response = restTemplate.exchange(ENDPOINT, HttpMethod.GET, entity, String.class,
                 uriVariables);

--- a/src/main/java/edu/ucsb/cs156/spring/backenddemo/services/JokeQueryService.java
+++ b/src/main/java/edu/ucsb/cs156/spring/backenddemo/services/JokeQueryService.java
@@ -30,9 +30,9 @@ public class JokeQueryService {
         restTemplate = restTemplateBuilder.build();
     }
 
-    public static final String ENDPOINT = "https://v2.jokeapi.dev/joke/{category}?amount={numJokes}";
+    public static final String ENDPOINT = "https://v2.jokeapi.dev/joke/get?category={category}?amount={numJokes}";
 
-    public String getJSON(String category, int numJokes) throws HttpClientErrorException {
+    public String getJSON(String category, String numJokes) throws HttpClientErrorException {
         log.info("category={}, numJokes={}", category, numJokes);
 
         HttpHeaders headers = new HttpHeaders();
@@ -42,7 +42,7 @@ public class JokeQueryService {
 
         Map<String, String> uriVariables = Map.of(
             "category", category,
-            "numJokes", Integer.toString(numJokes)
+            "numJokes", numJokes
         );
 
         ResponseEntity<String> response = restTemplate.exchange(ENDPOINT, HttpMethod.GET, entity, String.class,

--- a/src/test/java/edu/ucsb/cs156/spring/backenddemo/controllers/JokeControllerTests.java
+++ b/src/test/java/edu/ucsb/cs156/spring/backenddemo/controllers/JokeControllerTests.java
@@ -1,0 +1,60 @@
+package edu.ucsb.cs156.spring.backenddemo.controllers;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.MvcResult;
+
+import edu.ucsb.cs156.spring.backenddemo.services.JokeQueryService;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.Mockito.when;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.times;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.HashMap;
+import java.util.Map;
+
+import org.springframework.http.HttpHeaders;
+
+@WebMvcTest(value = JokeController.class)
+
+public class JokeControllerTests {
+    private ObjectMapper mapper = new ObjectMapper();
+    @Autowired
+    private MockMvc mockMvc;
+    @MockBean
+    JokeQueryService mockJokeQueryService;
+
+    @Test
+    public void test_getJokes() throws Exception {
+    
+        String fakeJsonResult="{ \"fake\" : \"result\" }";
+        String numJokes = "1";
+        String category = "Misc";
+        when(mockJokeQueryService.getJSON(eq(category),eq(numJokes))).thenReturn(fakeJsonResult);
+
+        String url = String.format("/api/jokes/get?category=%s&amount=%s",category,numJokes);
+
+        MvcResult response = mockMvc
+            .perform( get(url).contentType("application/json"))
+            .andExpect(status().isOk()).andReturn();
+
+        String responseString = response.getResponse().getContentAsString();
+
+        assertEquals(fakeJsonResult, responseString);
+    }
+    
+}
+

--- a/src/test/java/edu/ucsb/cs156/spring/backenddemo/controllers/JokeControllerTests.java
+++ b/src/test/java/edu/ucsb/cs156/spring/backenddemo/controllers/JokeControllerTests.java
@@ -41,11 +41,11 @@ public class JokeControllerTests {
     public void test_getJokes() throws Exception {
     
         String fakeJsonResult="{ \"fake\" : \"result\" }";
-        String numJokes = "1";
+        String amount = "1";
         String category = "Misc";
-        when(mockJokeQueryService.getJSON(eq(category),eq(numJokes))).thenReturn(fakeJsonResult);
+        when(mockJokeQueryService.getJSON(eq(category),eq(amount))).thenReturn(fakeJsonResult);
 
-        String url = String.format("/api/jokes/get?category=%s&amount=%s",category,numJokes);
+        String url = String.format("/api/jokes/get?category=%s&amount=%s", category, amount);
 
         MvcResult response = mockMvc
             .perform( get(url).contentType("application/json"))

--- a/src/test/java/edu/ucsb/cs156/spring/backenddemo/services/JokeQueryServiceTests.java
+++ b/src/test/java/edu/ucsb/cs156/spring/backenddemo/services/JokeQueryServiceTests.java
@@ -25,10 +25,10 @@ public class JokeQueryServiceTests {
     public void test_getJSON() {
         /* possible categories are:"Any, Misc, Programming, Dark, Pun, Spooky, Christmas */
         String category = "Misc";
-        String numJokes = "1";
+        String amount = "1";
         
         String expectedURL = JokeQueryService.ENDPOINT.replace("{category}", category)
-                                                     .replace("{numJokes}", numJokes);
+                                                     .replace("{amount}", amount);
 
         String fakeJsonResult = "{ \"fake\" : \"result\" }";
 
@@ -37,7 +37,7 @@ public class JokeQueryServiceTests {
                                   .andExpect(header("Content-Type", MediaType.APPLICATION_JSON_VALUE))
                                   .andRespond(withSuccess(fakeJsonResult, MediaType.APPLICATION_JSON));
 
-        String actualResult = jokeQueryService.getJSON(category, numJokes);
+        String actualResult = jokeQueryService.getJSON(category, amount);
         assertEquals(fakeJsonResult, actualResult);
     }
 }

--- a/src/test/java/edu/ucsb/cs156/spring/backenddemo/services/JokeQueryServiceTests.java
+++ b/src/test/java/edu/ucsb/cs156/spring/backenddemo/services/JokeQueryServiceTests.java
@@ -25,10 +25,10 @@ public class JokeQueryServiceTests {
     public void test_getJSON() {
         /* possible categories are:"Any, Misc, Programming, Dark, Pun, Spooky, Christmas */
         String category = "Misc";
-        int numJokes = 1;
+        String numJokes = "1";
         
         String expectedURL = JokeQueryService.ENDPOINT.replace("{category}", category)
-                                                     .replace("{numJokes}", Integer.toString(numJokes));
+                                                     .replace("{numJokes}", numJokes);
 
         String fakeJsonResult = "{ \"fake\" : \"result\" }";
 

--- a/src/test/java/edu/ucsb/cs156/spring/backenddemo/services/JokeQueryServiceTests.java
+++ b/src/test/java/edu/ucsb/cs156/spring/backenddemo/services/JokeQueryServiceTests.java
@@ -1,0 +1,43 @@
+package edu.ucsb.cs156.spring.backenddemo.services;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.client.RestClientTest;
+import org.springframework.http.MediaType;
+import org.springframework.test.web.client.MockRestServiceServer;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.springframework.test.web.client.match.MockRestRequestMatchers.requestTo;
+import static org.springframework.test.web.client.response.MockRestResponseCreators.withSuccess;
+import static org.springframework.test.web.client.match.MockRestRequestMatchers.header;
+
+@RestClientTest(JokeQueryService.class)
+public class JokeQueryServiceTests {
+
+    @Autowired
+    private MockRestServiceServer mockRestServiceServer;
+
+    @Autowired
+    private JokeQueryService jokeQueryService;
+
+    @Test
+    public void test_getJSON() {
+        /* possible categories are:"Any, Misc, Programming, Dark, Pun, Spooky, Christmas */
+        String category = "Misc";
+        int numJokes = 1;
+        
+        String expectedURL = JokeQueryService.ENDPOINT.replace("{category}", category)
+                                                     .replace("{numJokes}", Integer.toString(numJokes));
+
+        String fakeJsonResult = "{ \"fake\" : \"result\" }";
+
+        this.mockRestServiceServer.expect(requestTo(expectedURL))
+                                  .andExpect(header("Accept", MediaType.APPLICATION_JSON_VALUE))
+                                  .andExpect(header("Content-Type", MediaType.APPLICATION_JSON_VALUE))
+                                  .andRespond(withSuccess(fakeJsonResult, MediaType.APPLICATION_JSON));
+
+        String actualResult = jokeQueryService.getJSON(category, numJokes);
+        assertEquals(fakeJsonResult, actualResult);
+    }
+}


### PR DESCRIPTION
In this PR,
- Added an endpoint `/api/jokes/get` that can be used to get a chosen amount of jokes in a certain category. 
- Made minor change on Joke Service so the input parameter is String instead of int. 

Dev deployment link: http://team01-xinyao-dev.dokku-16.cs.ucsb.edu/swagger-ui/index.html
Test coverage for the controller can be seen below with report from jacoco:
<img width="1035" alt="Screenshot 2024-04-17 at 9 51 15 PM" src="https://github.com/ucsb-cs156-s24/team01-s24-5pm-8/assets/42160992/6e93009d-a36d-4f1c-97cc-d8b5cb947fb8">

P.S. Review and merge #6 first to avoid merge conflict. 

Closes #7 